### PR TITLE
Fix sync command

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1398,6 +1398,7 @@ local function sendStuff()
 		deleteStamp(stampName)
 		local d = #s
 		local b1,b2,b3 = math.floor(x/16),((x%16)*16)+math.floor(y/256),(y%256)
+		conSend(63)
 		conSend(67,string.char(math.floor(x/16),((x%16)*16)+math.floor(y/256),(y%256),math.floor((x+w)/16),(((x+w)%16)*16)+math.floor((y+h)/256),((y+h)%256)))
 		conSend(66,string.char(b1,b2,b3,math.floor(d/65536),math.floor(d/256)%256,d%256)..s)
 	end


### PR DESCRIPTION
Currently, sync causes lots of problems with stacking and pressure. This helps fix that problem by clearing the screen before sending sync.
